### PR TITLE
fix: app crash on android MethodChannel.Result submitted twice

### DIFF
--- a/android/src/main/kotlin/com/example/scgateway_flutter_plugin/ScgatewayMethodChannelResult.kt
+++ b/android/src/main/kotlin/com/example/scgateway_flutter_plugin/ScgatewayMethodChannelResult.kt
@@ -4,17 +4,26 @@ import android.app.Activity
 import io.flutter.plugin.common.MethodChannel
 
 class ScgatewayMethodChannelResult(val rawResult: MethodChannel.Result, val activity: Activity) : MethodChannel.Result {
+    private var isResponseSubmitted = false
+
     override fun success(result: Any?) {
-        activity.runOnUiThread { rawResult.success(result) }
+        activity.runOnUiThread { 
+            rawResult.success(result) 
+            isResponseSubmitted = true
+        }
     }
 
     override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
-        activity.runOnUiThread { rawResult.error(errorCode, errorMessage, errorDetails) }
+        activity.runOnUiThread { 
+            rawResult.error(errorCode, errorMessage, errorDetails)
+            isResponseSubmitted = true
+        }
     }
 
     override fun notImplemented() {
         activity.runOnUiThread {
             rawResult.notImplemented()
+            isResponseSubmitted = true
         }
     }
 }


### PR DESCRIPTION
App crash in MF_HOLDINGS_IMPORT