### PR TITLE
release(prod): scloans 5.4.1

### DIFF
--- a/loans/CHANGELOG.md
+++ b/loans/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.1
+
+- Update Android native SDK dependency to 5.3.1.
+
 ## 5.4.0
 
 - Update Android native SDK dependency to 5.3.0.

--- a/loans/android/build.gradle
+++ b/loans/android/build.gradle
@@ -64,5 +64,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.smallcase.loans:sdk:5.3.0'
+    implementation 'com.smallcase.loans:sdk:5.3.1'
 }

--- a/loans/pubspec.yaml
+++ b/loans/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scloans
 description: Scloans flutter plugin.
-version: 5.4.0
+version: 5.4.1
 homepage: https://github.com/smallcase/gw-mob-sdk-flutter
 
 environment:

--- a/smart_investing/pubspec.lock
+++ b/smart_investing/pubspec.lock
@@ -525,7 +525,7 @@ packages:
       path: "../loans"
       relative: true
     source: path
-    version: "5.4.0"
+    version: "5.4.1"
   shelf:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- update the Android Loans SDK dependency from 5.3.0 to 5.3.1
- bump the scloans Flutter package from 5.4.0 to 5.4.1
- update the package changelog and example lockfile

## Impact

Flutter consumers will receive LoanSDK Android 5.3.1 through scloans 5.4.1.

## Validation

- `flutter analyze` — passed with no issues
- `flutter test` — package has no `test/` directory
- Android artifact dependency resolution remains to be verified against the published `com.smallcase.loans:sdk:5.3.1` artifact